### PR TITLE
Adding web server VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 Use this to play around with scrapy without mucking around with your personal system.
 
 What this does:
-- Creates a Vagrant box with a Python dev environment for working on scrapy
+- Creates a Vagrant box with a Python dev environment for working on scrapy (called `scrapy-vm`)
+  - Default IP for this box is 10.10.10.9
+- Creates a Vagrant box running Apache for serving test sites (called `web`)
+  - Default IP for this box is 10.10.10.10
+  - This serves up any pages found in this directory's `web/html` subdirectory
+  - To view pages served from this VM, point your browser to `http://10.10.10.10`
 - Sets up your scrapy fork on the VM in editable mode (meaning that any changes made to the codebase should be reflected when executing scrapy)
 - Enables SSH agent forwarding on the VM, so you can use your SSH keys for interacting with GitHub and others from within the VM (if you have SSH agent forwarding set up on your system and change the remote repo's URL to SSH in `.git/config`)
 
@@ -16,16 +21,19 @@ Requirements for setup:
 
 Usage:
 - Navigate to the directory containing this Vagrantfile
-- Start the VM (will provision/setup the VM the first time you run this): `vagrant up`
+- Start the VMs you want to use (will provision/setup each VM the first time you run this): `vagrant up <boxname>`
+  - Running `vagrant up` without specifying a VM name will start up `scrapy-vm` but not `web`.
   - First-time setup will take some time, as it has to download a Vagrant box (essentially a VM disk file). This typically takes ~30 minutes on a decent connection, but may take longer. 
   - You may see an error about Window System drivers when the provisioning process sets up Guest Additions. Don't worry about it (it's only pertinent for GUI stuff, which we won't be using). 
-- Log into the VM: `vagrant ssh`
-  - Once logged in, you can run scrapy straight from the commandline
+- Log into a specific VM: `vagrant ssh <boxname>`
+  - Once logged into `scrapy-vm`, you can run scrapy straight from the commandline
   - Local directory containing Vagrantfile is shared with the VM at `/vagrant`
-    - Changes made to `/vagrant` directory will persist across VM sessions
+    - `web` uses `/vagrant/web/html` as its document root for now
+    - Changes made to anything in the `/vagrant` directory will persist across VM sessions
   - To exit the VM: `exit` or `logout`
-- Stop the VM: `vagrant halt`
-- If you encounter some issue with the setup proocess and need to start over again: `vagrant destroy`
-  - Note: this won't touch your `scrapy` directory
+- Stop all VMs: `vagrant halt`
+- Stop a specific VM: `vagrant halt <boxname>`
+- If you encounter some issue with the setup proocess and need to start over again: `vagrant destroy <boxname>`
+  - Note: this won't touch your `scrapy` or `web` directories
 - If you didn't clone your scrapy fork before setting up your VM, you'll have to reload your VM (it's a fairly quick process compared to destroy/up). From the scrapy-vagrant directory:
-  - `vagrant reload --provision`
+  - `vagrant reload <boxname> --provision` or `vagrant up <boxname> --provision`

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -2,34 +2,62 @@
 # vi: set ft=ruby :
 
 Vagrant.configure(2) do |config|
-  config.vm.box = "ubuntu/trusty64"
-  config.vm.hostname = "scrapy-vm"
- 
-  # We can use this later for pulling from the team repo if everybody is
-  # set up with ssh forwarding.
-  config.ssh.forward_agent = true 
   
-  config.vm.provider "virtualbox" do |vb|
-    # We need at least this much for setup
-    vb.memory = "1024"
-    
-    # Sets up internet connectivity for vagrant
-    vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+  # Define the scrapy VM as the primary machine
+  config.vm.define "scrapy-vm", primary: true do |scrapy|
+    scrapy.vm.box = "ubuntu/trusty64"
+    scrapy.vm.hostname = "scrapy-vm"
+    scrapy.ssh.forward_agent = true 
+    scrapy.vm.network "private_network", ip: "10.10.10.9"
+    scrapy.vm.provider "virtualbox" do |vb|
+      # We need at least this much for setup
+      vb.memory = "1024"
+      # Sets up internet connectivity for vagrant
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    end
+
+    # Install the necessary packages, switch to our shared directory, check if
+    # our project directory exists, and clone it if it doesn't.
+    scrapy.vm.provision "shell", inline: <<-SHELL
+      sudo apt-get update
+      sudo apt-get install -y build-essential libssl-dev libffi-dev python-dev python3-dev libxml2-dev libxslt1-dev git
+      sudo apt-get install -y python-pip python3-pip
+      cd /vagrant
+      if [ -d scrapy ]; then
+        cd scrapy
+        pip install -e .
+      else
+        echo "/vagrant/scrapy project directory not found, not installing!"
+        echo "You can set up your fork later, see README.md for details."
+      fi
+    SHELL
   end
 
-  # Install the necessary packages, switch to our shared directory, check if
-  # our project directory exists, and clone it if it doesn't.
-  config.vm.provision "shell", inline: <<-SHELL
-    sudo apt-get update
-    sudo apt-get install -y build-essential libssl-dev libffi-dev python-dev python3-dev libxml2-dev libxslt1-dev git
-    sudo apt-get install -y python-pip python3-pip
-    cd /vagrant
-    if [ -d scrapy ]; then
-      cd scrapy
-      pip install -e .
-    else
-      echo "/vagrant/scrapy project directory not found, not installing!"
-      echo "You can set up your fork later, see README.md for details."
-    fi
-  SHELL
+  # Don't start up the web VM by default
+  config.vm.define "web", autostart: false do |web|
+    web.vm.box = "ubuntu/trusty64"
+    web.vm.hostname = "web-vm"
+    web.ssh.forward_agent = true
+    web.vm.network "private_network", ip: "10.10.10.10"
+    web.vm.provider "virtualbox" do |vb|
+      # Keeping it small for now
+      vb.memory = "512"
+      # Sets up internet connectivity for vagrant
+      vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
+    end
+
+    # Install apache, remove the old document root, create and
+    # symlink the new document root
+    web.vm.provision "shell", inline: <<-SHELL
+      sudo apt-get update
+      sudo apt-get install -y apache2
+      if ! [ -L /var/www ]; then
+        sudo rm -rf /var/www
+        if ! [ -d /vagrant/web ]; then
+          mkdir -p /vagrant/web/html
+        fi
+        ln -fs /vagrant/web /var/www
+      fi
+    SHELL
+  end
 end


### PR DESCRIPTION
This adds a simple web server to Vagrant. It uses a bare-bones config that serves up pages residing in `[scrapy-vagrant directory]/web/html`.
